### PR TITLE
Use node path module instead path-browserify when not running on browser.

### DIFF
--- a/packages/oas-resolver/index.js
+++ b/packages/oas-resolver/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const fs = require('fs');
-const path = require('path-browserify');
+const path = typeof process === 'object' ? require('path') : require('path-browserify');
 const url = require('url');
 
 const fetch = require('node-fetch-h2');


### PR DESCRIPTION
This PR will add support for using the native path module for all platforms other than the browser.